### PR TITLE
Fixed bug where error credentials count as sign in

### DIFF
--- a/main/scan.py
+++ b/main/scan.py
@@ -75,7 +75,7 @@ def get_credentials(mac_address: str, totp: int):
         return data.get("username", "invalid"), data.get("password", "invalid")
     except requests.exceptions.RequestException as e:
         logging.error(f"Error fetching credentials for MAC address {mac_address}: {e}")
-        return "error", "error"
+        
 
 class ScanDelegate(DefaultDelegate):
     def __init__(self):
@@ -158,7 +158,16 @@ def scan_devices():
         if user_found is not None:
             mac_address = all_usernames[user_found]
             totp = devices[mac_address]['value']
-            username, password = get_credentials(mac_address, totp)
+            try:
+                credentials = get_credentials(mac_address, totp)
+                if credentials is None:
+                    logging.error("Failed to get credentials.")
+                    continue
+                username, password = credentials
+            except Exception as e:
+                logging.error(f"Exception occurred: {e}")
+                continue
+
             logging.warning("Sending credentials to Pico")
             uart_rpi5.write_to_pico(username, password)
             


### PR DESCRIPTION
This pull request includes changes to improve error handling and logging in the `main/scan.py` file. The most important changes include modifying the `get_credentials` function to remove an unnecessary return statement and enhancing the `scan_devices` function with better error handling and logging.

Error handling and logging improvements:

* [`main/scan.py`](diffhunk://#diff-5fb814ac3d74628dd0f70303f1adeb6a2ffa16c69aeb4f23d1b3b9edad8bc6f3L78-R78): Removed an unnecessary return statement in the `get_credentials` function.
* [`main/scan.py`](diffhunk://#diff-5fb814ac3d74628dd0f70303f1adeb6a2ffa16c69aeb4f23d1b3b9edad8bc6f3L161-R170): Enhanced the `scan_devices` function by adding a try-except block to handle exceptions when calling `get_credentials`, and added logging for failed credential retrievals.